### PR TITLE
Add Streamlit MVP with spaced repetition scaffolding

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,0 +1,14 @@
+# Image Attributions
+
+Image sources are placeholders from [Picsum](https://picsum.photos). Replace with Macaulay Library images and appropriate credits.
+
+| Species | URL | License | Credit |
+| --- | --- | --- | --- |
+| Downy Woodpecker | https://picsum.photos/seed/dowo/400/300 | CC BY-NC 4.0 | TBD |
+| Hairy Woodpecker | https://picsum.photos/seed/hawo/400/300 | CC BY-NC 4.0 | TBD |
+| House Finch | https://picsum.photos/seed/hofi/400/300 | CC BY-NC 4.0 | TBD |
+| Purple Finch | https://picsum.photos/seed/pufi/400/300 | CC BY-NC 4.0 | TBD |
+| Cooper's Hawk | https://picsum.photos/seed/coop/400/300 | CC BY-NC 4.0 | TBD |
+| Sharp-shinned Hawk | https://picsum.photos/seed/ssha/400/300 | CC BY-NC 4.0 | TBD |
+| Chipping Sparrow | https://picsum.photos/seed/chsp/400/300 | CC BY-NC 4.0 | TBD |
+| American Tree Sparrow | https://picsum.photos/seed/atsp/400/300 | CC BY-NC 4.0 | TBD |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# nerdID
+
+Simple Streamlit app for bird identification practice. The app quizzes you with one image and four options, logs your attempts, and tracks spaced-repetition state.
+
+## Setup (Windows PowerShell)
+
+```powershell
+python -m venv .venv
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\.venv\Scripts\Activate.ps1
+pip install streamlit pandas requests pillow
+```
+
+## Running the app
+
+```powershell
+streamlit run app.py
+```
+
+## Preparing data
+
+```powershell
+python prep.py validate data/items.csv
+python prep.py cache --csv data/items.csv --dir cache
+```
+
+## Tests
+
+```powershell
+python -m unittest
+```
+
+Replace the placeholder image URLs in `data/items.csv` with real Macaulay Library assets and fill in the proper license and credit information.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,147 @@
+import hashlib
+import io
+import random
+import time
+from datetime import date, datetime
+from pathlib import Path
+
+import pandas as pd
+import requests
+import sqlite3
+import streamlit as st
+from PIL import Image
+
+import sr
+
+DATA_CSV = Path("data/items.csv")
+REVIEWS_CSV = Path("data/reviews.csv")
+CACHE_DIR = Path("cache")
+DB_PATH = Path("data/sr_state.sqlite")
+
+
+def get_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sr_state (
+            species_code TEXT PRIMARY KEY,
+            reps INTEGER,
+            interval_days INTEGER,
+            easiness REAL,
+            due_at TEXT
+        )
+        """
+    )
+    return conn
+
+
+def load_state(conn, code):
+    cur = conn.execute(
+        "SELECT reps, interval_days, easiness, due_at FROM sr_state WHERE species_code=?",
+        (code,),
+    )
+    row = cur.fetchone()
+    if row:
+        reps, interval, easiness, due_at = row
+        return {
+            "reps": reps,
+            "interval_days": interval,
+            "easiness": easiness,
+            "due_at": due_at,
+        }
+    return {
+        "reps": 0,
+        "interval_days": 0,
+        "easiness": 2.5,
+        "due_at": date.today().isoformat(),
+    }
+
+
+def save_state(conn, code, state):
+    conn.execute(
+        "REPLACE INTO sr_state (species_code,reps,interval_days,easiness,due_at) VALUES (?,?,?,?,?)",
+        (
+            code,
+            state["reps"],
+            state["interval_days"],
+            state["easiness"],
+            state["due_at"],
+        ),
+    )
+    conn.commit()
+
+
+def get_image(url: str):
+    CACHE_DIR.mkdir(exist_ok=True)
+    h = hashlib.md5(url.encode()).hexdigest() + ".jpg"
+    path = CACHE_DIR / h
+    if path.exists():
+        return Image.open(path)
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        img = Image.open(io.BytesIO(resp.content)).convert("RGB")
+        img.save(path, format="JPEG")
+        return img
+    except Exception:
+        return None
+
+
+def pick_item(df, conn):
+    today = date.today().isoformat()
+    due_codes = [
+        code
+        for code in df["species_code"].unique()
+        if load_state(conn, code)["due_at"] <= today
+    ]
+    pool = df[df["species_code"].isin(due_codes)] if due_codes else df
+    return pool.sample(1).iloc[0]
+
+
+def main():
+    df = pd.read_csv(DATA_CSV)
+    conn = get_conn()
+    item = pick_item(df, conn)
+    group = df[df.group_id == item.group_id].drop_duplicates("species_code")
+    if len(group) < 4:
+        st.error("Need at least 4 species in group")
+        st.stop()
+    options = group.sample(4).reset_index(drop=True)
+    correct_index = int(options.index[options.species_code == item.species_code][0])
+
+    img = get_image(item.image_url)
+    if img:
+        st.image(img, caption=f"{item['license']} — {item['credit']}")
+    else:
+        st.write("Image unavailable")
+
+    if "start_time" not in st.session_state:
+        st.session_state.start_time = time.time()
+    choice = st.radio("Which bird is this?", options["common_name"].tolist())
+
+    if st.button("Submit"):
+        elapsed = int((time.time() - st.session_state.start_time) * 1000)
+        correct = choice == item.common_name
+        st.write("Correct!" if correct else f"Nope, it was {item.common_name}")
+        with REVIEWS_CSV.open("a") as f:
+            chosen_code = options.loc[options.common_name == choice, "species_code"].iloc[0]
+            f.write(
+                f"{datetime.utcnow().isoformat()},{item.species_code},{chosen_code},{int(correct)},{elapsed}\n"
+            )
+        grade = 5 if correct else 2
+        state = load_state(conn, item.species_code)
+        new_state = sr.schedule(state, grade)
+        save_state(conn, item.species_code, new_state)
+        st.session_state.start_time = time.time()
+        st.experimental_rerun()
+
+    if REVIEWS_CSV.exists():
+        df_rev = pd.read_csv(REVIEWS_CSV)
+        if not df_rev.empty:
+            st.sidebar.metric("Overall accuracy", f"{df_rev['correct'].mean():.0%}")
+            acc = df_rev.groupby("species_code")["correct"].mean()
+            st.sidebar.bar_chart(acc)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/items.csv
+++ b/data/items.csv
@@ -1,0 +1,9 @@
+image_url,species_code,common_name,group_id,license,credit
+https://picsum.photos/seed/dowo/400/300,dowo,Downy Woodpecker,woodpecker,CC BY-NC 4.0,TBD
+https://picsum.photos/seed/hawo/400/300,hawo,Hairy Woodpecker,woodpecker,CC BY-NC 4.0,TBD
+https://picsum.photos/seed/hofi/400/300,hofi,House Finch,finch,CC BY-NC 4.0,TBD
+https://picsum.photos/seed/pufi/400/300,pufi,Purple Finch,finch,CC BY-NC 4.0,TBD
+https://picsum.photos/seed/coop/400/300,coha,Cooper's Hawk,hawk,CC BY-NC 4.0,TBD
+https://picsum.photos/seed/ssha/400/300,ssha,Sharp-shinned Hawk,hawk,CC BY-NC 4.0,TBD
+https://picsum.photos/seed/chsp/400/300,chsp,Chipping Sparrow,sparrow,CC BY-NC 4.0,TBD
+https://picsum.photos/seed/atsp/400/300,atsp,American Tree Sparrow,sparrow,CC BY-NC 4.0,TBD

--- a/data/reviews.csv
+++ b/data/reviews.csv
@@ -1,0 +1,1 @@
+ts,species_code,choice_code,correct,response_ms

--- a/prep.py
+++ b/prep.py
@@ -1,0 +1,66 @@
+import argparse
+import hashlib
+import os
+from pathlib import Path
+from io import BytesIO
+
+import pandas as pd
+import requests
+from PIL import Image
+
+REQUIRED_COLS = [
+    "image_url",
+    "species_code",
+    "common_name",
+    "group_id",
+    "license",
+    "credit",
+]
+
+
+def cmd_validate(csv_path: str) -> None:
+    df = pd.read_csv(csv_path)
+    missing = [c for c in REQUIRED_COLS if c not in df.columns]
+    if missing:
+        raise SystemExit(f"Missing columns: {', '.join(missing)}")
+    if df[REQUIRED_COLS].isnull().any().any():
+        raise SystemExit("Blank values found in required columns")
+    print("Validation OK")
+
+
+def cmd_cache(csv_path: str, out_dir: str) -> None:
+    df = pd.read_csv(csv_path)
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    for url in df["image_url"].unique():
+        h = hashlib.md5(url.encode()).hexdigest() + ".jpg"
+        dest = out / h
+        if dest.exists():
+            continue
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            img = Image.open(BytesIO(resp.content)).convert("RGB")
+            img.save(dest, format="JPEG")
+            print(f"cached {url} -> {dest}")
+        except Exception as e:
+            print(f"failed {url}: {e}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_val = sub.add_parser("validate")
+    p_val.add_argument("csv")
+    p_cache = sub.add_parser("cache")
+    p_cache.add_argument("--csv", required=True)
+    p_cache.add_argument("--dir", required=True)
+    args = parser.parse_args(argv)
+    if args.cmd == "validate":
+        cmd_validate(args.csv)
+    elif args.cmd == "cache":
+        cmd_cache(args.csv, args.dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/sr.py
+++ b/sr.py
@@ -1,0 +1,40 @@
+from datetime import date, timedelta
+
+
+def schedule(state, grade):
+    """Update SM-2 schedule state.
+
+    Args:
+        state (dict): Existing state with keys reps, interval_days, easiness, due_at.
+        grade (int): 0-5 performance rating.
+
+    Returns:
+        dict: Updated state with same keys.
+    """
+    reps = state.get("reps", 0)
+    interval = state.get("interval_days", 0)
+    easiness = state.get("easiness", 2.5)
+
+    if grade >= 3:
+        if reps == 0:
+            interval = 1
+        elif reps == 1:
+            interval = 6
+        else:
+            interval = round(interval * easiness)
+        reps += 1
+    else:
+        reps = 0
+        interval = 1
+
+    easiness = easiness + (0.1 - (5 - grade) * (0.08 + (5 - grade) * 0.02))
+    easiness = max(1.3, easiness)
+
+    due_at = date.today() + timedelta(days=interval)
+
+    return {
+        "reps": reps,
+        "interval_days": interval,
+        "easiness": easiness,
+        "due_at": due_at.isoformat(),
+    }

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -1,0 +1,28 @@
+import tempfile
+import unittest
+
+import pandas as pd
+
+import prep
+
+
+class TestPrep(unittest.TestCase):
+    def test_validate_ok(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
+            f.write(
+                "image_url,species_code,common_name,group_id,license,credit\n"
+                "u,x,y,g,l,c\n"
+            )
+            name = f.name
+        prep.cmd_validate(name)
+
+    def test_validate_missing(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
+            f.write("image_url,common_name\nhttps://example.com,img\n")
+            name = f.name
+        with self.assertRaises(SystemExit):
+            prep.cmd_validate(name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sr.py
+++ b/tests/test_sr.py
@@ -1,0 +1,23 @@
+import unittest
+
+from sr import schedule
+
+
+class TestSchedule(unittest.TestCase):
+    def test_correct(self):
+        state = {"reps": 0, "interval_days": 0, "easiness": 2.5, "due_at": ""}
+        out = schedule(state, 5)
+        self.assertEqual(out["reps"], 1)
+        self.assertEqual(out["interval_days"], 1)
+        self.assertGreater(out["easiness"], 2.5)
+
+    def test_incorrect(self):
+        state = {"reps": 2, "interval_days": 6, "easiness": 2.5, "due_at": ""}
+        out = schedule(state, 2)
+        self.assertEqual(out["reps"], 0)
+        self.assertEqual(out["interval_days"], 1)
+        self.assertGreaterEqual(out["easiness"], 1.3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implement Streamlit app with image quiz, logging, and spaced-repetition state stored in SQLite
- Provide CLI prep utility for CSV validation and image caching
- Include SM-2 scheduler, test suite, starter dataset, and project README

## Testing
- `python prep.py validate data/items.csv` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python prep.py cache --csv data/items.csv --dir cache` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b14606a74c832cb22fbe491a7024f1