### PR TITLE
Add species list builder for Indiana via eBird API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ python prep.py validate data/items.csv
 python prep.py cache --csv data/items.csv --dir cache
 ```
 
+## Building state species list
+
+Download the eBird/Clements v2024 taxonomy CSV and set the `EBIRD_API_KEY`
+environment variable to your eBird API token. Then generate a species list for
+Indiana with:
+
+```powershell
+python prep.py species --taxonomy path\to\ebird_taxonomy_v2024.csv --region US-IN --out data/indiana_species.csv
+```
+
 ## Tests
 
 ```powershell


### PR DESCRIPTION
## Summary
- add `species` subcommand to `prep.py` for generating region species lists using the eBird API and Clements taxonomy
- document new species list command in README

## Testing
- `python -m unittest`
- `python prep.py species --taxonomy data/ebird_taxonomy_v2024.csv --region US-IN --out data/indiana_species.csv` *(fails: EBIRD_API_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b1493df860832ca25262c82c01056b