### PR TITLE
Handle small groups by sampling fallback species

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from app import build_options
+
+
+def test_build_options_adds_fallback_species():
+    df = pd.DataFrame([
+        {"species_code": "a", "common_name": "A", "group_id": 1, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "b", "common_name": "B", "group_id": 2, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "c", "common_name": "C", "group_id": 2, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "d", "common_name": "D", "group_id": 3, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "e", "common_name": "E", "group_id": 4, "image_url": "", "license": "", "credit": ""},
+    ])
+    item = df.iloc[0]
+    options = build_options(df, item)
+    assert len(options) == 4
+    assert item.species_code in options.species_code.values
+    assert options["species_code"].is_unique


### PR DESCRIPTION
## Summary
- Allow quiz to work with small species groups by sampling extra species from other groups
- Add tests to ensure option builder always returns four unique species

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b151e90708832c9fc7f8a98f43215a