### PR TITLE
Handle small groups by sampling fallback species

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,15 +98,45 @@ def pick_item(df, conn):
     return pool.sample(1).iloc[0]
 
 
+def build_options(df: pd.DataFrame, item: pd.Series, n: int = 4) -> pd.DataFrame:
+    """Return *n* answer options including the correct species.
+
+    If the item's group does not contain enough species to provide all
+    options, the remaining slots are filled with random species from other
+    groups. The returned DataFrame is shuffled and contains one row per
+    species.
+    """
+
+    group = df[df.group_id == item.group_id].drop_duplicates("species_code")
+    if len(group) >= n:
+        return group.sample(n).reset_index(drop=True)
+
+    others = df[df.group_id != item.group_id].drop_duplicates("species_code")
+    needed = n - len(group)
+    filler = others.sample(needed)
+    options = pd.concat([group, filler]).sample(n).reset_index(drop=True)
+    return options
+
+
+def rerun_app() -> None:
+    """Rerun the Streamlit app using the available API.
+
+    Streamlit renamed ``st.experimental_rerun`` to ``st.rerun`` in newer
+    versions. This helper calls the preferred ``st.rerun`` when present while
+    remaining compatible with older versions.
+    """
+
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:  # pragma: no cover - exercised in a test with a stub
+        st.experimental_rerun()
+
+
 def main():
     df = pd.read_csv(DATA_CSV)
     conn = get_conn()
     item = pick_item(df, conn)
-    group = df[df.group_id == item.group_id].drop_duplicates("species_code")
-    if len(group) < 4:
-        st.error("Need at least 4 species in group")
-        st.stop()
-    options = group.sample(4).reset_index(drop=True)
+    options = build_options(df, item)
     correct_index = int(options.index[options.species_code == item.species_code][0])
 
     img = get_image(item.image_url)
@@ -133,7 +163,7 @@ def main():
         new_state = sr.schedule(state, grade)
         save_state(conn, item.species_code, new_state)
         st.session_state.start_time = time.time()
-        st.experimental_rerun()
+        rerun_app()
 
     if REVIEWS_CSV.exists():
         df_rev = pd.read_csv(REVIEWS_CSV)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from types import SimpleNamespace
+
+import app
+from app import build_options, rerun_app
+
+
+def test_build_options_adds_fallback_species():
+    df = pd.DataFrame([
+        {"species_code": "a", "common_name": "A", "group_id": 1, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "b", "common_name": "B", "group_id": 2, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "c", "common_name": "C", "group_id": 2, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "d", "common_name": "D", "group_id": 3, "image_url": "", "license": "", "credit": ""},
+        {"species_code": "e", "common_name": "E", "group_id": 4, "image_url": "", "license": "", "credit": ""},
+    ])
+    item = df.iloc[0]
+    options = build_options(df, item)
+    assert len(options) == 4
+    assert item.species_code in options.species_code.values
+    assert options["species_code"].is_unique
+
+
+def test_rerun_app_prefers_new_api(monkeypatch):
+    calls = []
+
+    def new_rerun():
+        calls.append("new")
+
+    def old_rerun():
+        calls.append("old")
+
+    dummy = SimpleNamespace(rerun=new_rerun, experimental_rerun=old_rerun)
+    monkeypatch.setattr(app, "st", dummy)
+
+    rerun_app()
+    assert calls == ["new"]
+
+
+def test_rerun_app_falls_back_to_experimental(monkeypatch):
+    calls = []
+
+    def old_rerun():
+        calls.append("old")
+
+    dummy = SimpleNamespace(experimental_rerun=old_rerun)
+    monkeypatch.setattr(app, "st", dummy)
+
+    rerun_app()
+    assert calls == ["old"]


### PR DESCRIPTION
## Summary
- Allow quiz to work with small species groups by sampling extra species from other groups
- Switch to Streamlit's stable rerun API with a compatibility helper
- Add tests to ensure option builder and rerun helper behave correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b151e90708832c9fc7f8a98f43215a